### PR TITLE
frozenlist 1.8.0: update for py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,8 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
+
+channels:
+  - https://staging.continuum.io/pbp/fs/pretend-feedstock/pr2/b07d20f
+  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr16/239c2c5
+  - https://staging.continuum.io/pbp/fs/hatchling-feedstock/pr9/f1bef63
+  - https://staging.continuum.io/pbp/fs/expandvars-feedstock/pr3/dc95d68

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,8 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY314 : yes
-
-channels:
-  - https://staging.continuum.io/pbp/fs/pretend-feedstock/pr2/b07d20f
-  - https://staging.continuum.io/pbp/fs/packaging-feedstock/pr16/239c2c5
-  - https://staging.continuum.io/pbp/fs/hatchling-feedstock/pr9/f1bef63
-  - https://staging.continuum.io/pbp/fs/expandvars-feedstock/pr3/dc95d68

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - cython >=3.1.4
     - expandvars
     - pip
-    - setuptools>=47
+    - setuptools >=47
     - tomli  # [py<311]
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "frozenlist" %}
-{% set version = "1.5.0" %}
+{% set version = "1.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,24 +7,25 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/frozenlist-{{ version }}.tar.gz
-  sha256: 81d5af29e61b9c8348e876d442253723928dce6433e0e76cd925cd83f1b4b817
+  sha256: 3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad
 
 build:
-  skip: true  # [py<38]
+  skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   host:
     - python
-    - pip
-    - setuptools
-    - wheel
-    - expandvars
-    - tomli # [py<311]
     - cython
+    - expandvars
+    - pip
+    - setuptools>=47
+    - tomli  # [py<311]
+    - wheel
   run:
     - python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - {{ compiler('cxx') }}
     - {{ stdlib('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,8 @@ requirements:
     - {{ stdlib('c') }}
   host:
     - python
-    - cython
+    # https://github.com/aio-libs/frozenlist/blob/v1.8.0/requirements/cython.txt#L1
+    - cython >=3.1.4
     - expandvars
     - pip
     - setuptools>=47

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   skip: true  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-10123](https://anaconda.atlassian.net/browse/PKG-10123)
- [Upstream repo](https://github.com/aio-libs/frozenlist/tree/v1.8.0)
- requirements-tagged: 
  - https://github.com/aio-libs/frozenlist/blob/v1.8.0/setup.cfg
  - https://github.com/aio-libs/frozenlist/blob/v1.8.0/pyproject.toml 


### Explanation of changes:

- Add `ANACONDA_ROCKET_ENABLE_PY314 : yes` to `abs.yaml`
- Add `stdlib('c')` and `compiler('cxx')`
- Sort dependencies

[PKG-10123]: https://anaconda.atlassian.net/browse/PKG-10123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ